### PR TITLE
feat: fix .tmux.conf for version 2.1 or later #1

### DIFF
--- a/.tmux.conf
+++ b/.tmux.conf
@@ -248,10 +248,7 @@ bind e setw synchronize-panes on
 bind E setw synchronize-panes off
 
 # マウス操作を有効にする
-setw -g mode-mouse on
-set -g mouse-select-pane on
-set -g mouse-resize-pane on
-set -g mouse-select-window on
+set -g mouse on
 
 # 256色端末を使用する
 # set -g default-terminal screen-256color
@@ -293,10 +290,6 @@ set -g status-left "#[fg=green]Session: #S #[fg=yellow]#I #[fg=cyan]#P"
 ## 右パネルを設定する
 set -g status-right "#[fg=cyan][%Y-%m-%d(%a) %H:%M]"
 
-## 文字コード
-set-window-option -g utf8 on
-## ステータスバーのUTF-8サポートを有効にする
-set -g status-utf8 on
 ## リフレッシュの間隔を設定する(デフォルト 15秒)
 set -g status-interval 10
 ## ウィンドウリストの位置を中心寄せにする

--- a/README.md
+++ b/README.md
@@ -31,3 +31,6 @@ Typically, user name mail address are written on .local.gitconfig.
 ### local zshrc
 You can add and override setting on .zshrc.
 If you hope, add .zshrc_local at home directory.
+
+## Limitation
+- .tmux.conf expect tmux2.1 or later


### PR DESCRIPTION
- change mouse setting to new format
- remove utf-8 setting
    - on new tmux,  UTF8 detection happens automatically
    - mouse-utf8 and utf8 options are removed
    - see: https://raw.githubusercontent.com/tmux/tmux/master/CHANGES

**Attention**
Now, .tmux.conf is incompatible for version 2.0 or older.

close #1 